### PR TITLE
Implement URI scheme activation

### DIFF
--- a/xbsx2-uwp/Package.appxmanifest
+++ b/xbsx2-uwp/Package.appxmanifest
@@ -27,6 +27,13 @@
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
         <uap:DefaultTile Square71x71Logo="Assets\SmallTile.png" Wide310x150Logo="Assets\Wide310x150Logo.png" Square310x310Logo="Assets\LargeTile.png"/>
       </uap:VisualElements>
+      <Extensions>
+        <uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="xbsx2">
+            <uap:DisplayName>xbsx2</uap:DisplayName>
+          </uap:Protocol>
+        </uap:Extension>
+      </Extensions>
     </Application>
   </Applications>
   <Capabilities>

--- a/xbsx2-uwp/URISchemeParser.cpp
+++ b/xbsx2-uwp/URISchemeParser.cpp
@@ -1,0 +1,92 @@
+/*  XBSX2 - PS2 Emulator for Xbox Consoles
+ *
+ *  XBSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  XBSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with XBSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PrecompiledHeader.h"
+#include "URISchemeParser.h"
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.ApplicationModel.Activation.h>
+#include <sstream>
+#include <iomanip>
+
+using namespace winrt::Windows::ApplicationModel::Core;
+using namespace winrt::Windows::Foundation;
+using namespace winrt::Windows::ApplicationModel::Activation;
+using namespace winrt::Windows::System;
+
+bool URISchemeParser::IsInitialized()
+{
+	return m_initialized;
+}
+
+void URISchemeParser::ParseProtocolArgs(const IActivatedEventArgs& args)
+{
+	m_argc = NULL;
+	m_pArgv.clear();
+	m_argv.clear();
+
+	if (args.Kind() == ActivationKind::Protocol)
+	{
+		ProtocolActivatedEventArgs protocolArgs{args.as<ProtocolActivatedEventArgs>()};
+		WwwFormUrlDecoder query = protocolArgs.Uri().QueryParsed();
+
+		for (uint i = 0; i < query.Size(); i++)
+		{
+			IWwwFormUrlDecoderEntry arg = query.GetAt(i);
+
+			//parse command line string
+			if (arg.Name() == winrt::hstring(L"cmd"))
+			{
+				std::istringstream iss(winrt::to_string(arg.Value()));
+				std::string s;
+
+				//set escape character to null char to preserve backslashes in paths which are inside quotes, they get stripped by default
+				while (iss >> std::quoted(s, '"', (char)0))
+				{
+					m_argv.push_back(s);
+				}
+			}
+			else if (arg.Name() == winrt::hstring(L"launchOnExit"))
+			{
+				//if this UWP app is started using protocol with argument "launchOnExit", this gives an option to launch another app on exit,
+				//making it easy to integrate this app with other UWP frontends
+				m_launchOnExit = arg.Value();
+			}
+		}
+	}
+
+	m_argc = m_argv.size();
+	//convert to char* array compatible with argv
+	for (int i = 0; i < m_argv.size(); i++)
+	{
+		m_pArgv.push_back((char*)(m_argv.at(i)).c_str());
+	}
+	m_pArgv.push_back(nullptr);
+	m_initialized = true;
+}
+
+int URISchemeParser::GetArgc()
+{
+	return m_argc;
+}
+
+char** URISchemeParser::GetArgv()
+{	
+	return m_pArgv.data();
+}
+
+winrt::hstring URISchemeParser::GetLaunchOnExitURI()
+{
+	return m_launchOnExit;
+}
+

--- a/xbsx2-uwp/URISchemeParser.h
+++ b/xbsx2-uwp/URISchemeParser.h
@@ -1,0 +1,41 @@
+/*  XBSX2 - PS2 Emulator for Xbox Consoles
+ *
+ *  XBSX2 is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU Lesser General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  XBSX2 is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE.  See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with XBSX2.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <winrt/base.h>
+#include <winrt/Windows.ApplicationModel.Core.h>
+#include <winrt/Windows.Foundation.h>
+
+/* If the app is activated using protocol, it is expected to be in this format:
+* "xbsx2:?cmd=<PCSX2 CLI arguments>&launchOnExit=<app to launch on exit>"
+* For example:
+* xbsx2:?cmd=pcsx2.exe "c:\mypath\path with spaces\game.iso"&launchOnExit=LaunchApp:
+* "cmd" and "launchOnExit" are optional. If none specified, it will normally launch into menu
+*/
+class URISchemeParser
+{
+public:
+	bool IsInitialized();
+	void ParseProtocolArgs(const winrt::Windows::ApplicationModel::Activation::IActivatedEventArgs& args);
+	int	GetArgc();
+	char** GetArgv();
+	winrt::hstring GetLaunchOnExitURI();
+
+private:
+	bool m_initialized;
+	int m_argc = NULL;
+	std::vector<char*> m_pArgv;
+	std::vector<std::string> m_argv; //using std::string as temp buf instead of char* array to avoid manual char allocations
+	winrt::hstring m_launchOnExit;
+};

--- a/xbsx2-uwp/UWPNoGUIPlatform.h
+++ b/xbsx2-uwp/UWPNoGUIPlatform.h
@@ -20,6 +20,8 @@
 #include "common/RedtapeWindows.h"
 
 #include "NoGUIPlatform.h"
+#include "URISchemeParser.h"
+#include "VMManager.h"
 
 #include <winrt/Windows.ApplicationModel.Core.h>
 #include <winrt/Windows.Devices.Input.h>
@@ -72,8 +74,10 @@ public:
 	void SetWindow(const winrt::Windows::UI::Core::CoreWindow& window);
 
 	void OnUnhandledErrorDetected(const IInspectable&, const winrt::Windows::ApplicationModel::Core::UnhandledErrorDetectedEventArgs& args);
+	void OnActivated(const winrt::Windows::ApplicationModel::Core::CoreApplicationView&, const winrt::Windows::ApplicationModel::Activation::IActivatedEventArgs& args); 
 	void OnSuspending(const IInspectable&, const winrt::Windows::ApplicationModel::SuspendingEventArgs& args);
 	void OnResuming(const IInspectable&, const IInspectable&);
+	void OnEnteredBackground(const IInspectable& ,const winrt::Windows::ApplicationModel::EnteredBackgroundEventArgs& args);
 	void OnClosed(const IInspectable&, const winrt::Windows::UI::Core::CoreWindowEventArgs& args);
 	void OnSizeChanged(const IInspectable&, const winrt::Windows::UI::Core::WindowSizeChangedEventArgs& args);
 	void OnKeyDown(const IInspectable&, const winrt::Windows::UI::Core::KeyEventArgs& args);
@@ -92,4 +96,13 @@ private:
 	WindowInfo m_window_info = {};
 
 	bool m_last_mouse_state[3] = {};
+
+	//copied from pcsx2-nogui Main.cpp
+	std::shared_ptr<VMBootParameters> autoboot;
+	std::shared_ptr<VMBootParameters>& AutoBoot(std::shared_ptr<VMBootParameters>& autoboot);
+	bool ParseCommandLineOptions(int argc, char* argv[], std::shared_ptr<VMBootParameters>& autoboot);
+
+	//process arguments when app is activated using Uri Scheme
+	URISchemeParser m_uriSchemeParser;
+	bool m_launchOnExitShutdown;
 };

--- a/xbsx2-uwp/xbsx2-uwp.vcxproj
+++ b/xbsx2-uwp/xbsx2-uwp.vcxproj
@@ -184,6 +184,7 @@
     <ClCompile Include="PrecompiledHeader.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="URISchemeParser.cpp" />
     <ClCompile Include="UWPNoGUIPlatform.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -191,6 +192,7 @@
     <ClInclude Include="..\xbsx2-nogui\NoGUIPlatform.h" />
     <ClInclude Include="PrecompiledHeader.h" />
     <ClInclude Include="svnrev.h" />
+    <ClInclude Include="URISchemeParser.h" />
     <ClInclude Include="UWPKeyNames.h" />
     <ClInclude Include="UWPNoGUIPlatform.h" />
   </ItemGroup>

--- a/xbsx2-uwp/xbsx2-uwp.vcxproj.filters
+++ b/xbsx2-uwp/xbsx2-uwp.vcxproj.filters
@@ -4,6 +4,7 @@
     <ClCompile Include="PrecompiledHeader.cpp" />
     <ClCompile Include="UWPNoGUIPlatform.cpp" />
     <ClCompile Include="..\xbsx2-nogui\NoGUIHost.cpp" />
+    <ClCompile Include="URISchemeParser.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="PrecompiledHeader.h" />
@@ -12,6 +13,7 @@
     <ClInclude Include="svnrev.h" />
     <ClInclude Include="..\xbsx2-nogui\NoGUIHost.h" />
     <ClInclude Include="..\xbsx2-nogui\NoGUIPlatform.h" />
+    <ClInclude Include="URISchemeParser.h" />
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest" />


### PR DESCRIPTION
### Description

Implement URI activation so that XBSX2 UWP can be started by passing arguments. This makes it easy to integrate with other UWP apps/frontends.

PCSX2 emulator already has [CLI support](https://wiki.pcsx2.net/Command-line_support)
URI Scheme implementation in XBSX2 expects url to look like this:

- "xbsx2:?cmd=\<PCSX2 CLI arguments\>&launchOnExit=\<uri_app_protocol_to_launch_on_exit\>"
- "cmd" and "launchOnExit" are optional. If none specified, it will normally launch into menu

### Suggested Testing Steps
The easiest way to test running content is to:
1. open web browser and paste: **xbsx2:?cmd=pcsx2.exe "<full_path_to_rom>"**
2. content starts automatically

To test launch app on exit, this example will open edge browser after exiting XBSX2:
1. **xbsx2:?cmd=pcsx2.exe "<full_path_to_rom>"&launchOnExit=microsoft-edge:**
2. content starts automatically
3. stop content, exit XBSX2
4. Edge browser opens

Related feature request:
#21